### PR TITLE
feat(serial): add multi-MCU support with auto-config to Serial handler (#6)

### DIFF
--- a/vehicle_weighbridge/SerialReader.cpp
+++ b/vehicle_weighbridge/SerialReader.cpp
@@ -3,27 +3,153 @@
 #include <termios.h>  
 #include <unistd.h>
 #include <iostream>
+#include <cstring>
+#include <vector>
+#include <string>
+#include <dirent.h>
+
+namespace {
+    // Try common Linux device names. Prefer Raspberry Pi aliases first.
+    std::vector<std::string> getCandidatePorts() {
+        return {
+            "/dev/serial0",   // RPi alias (preferred)
+            "/dev/ttyAMA0",   // RPi PL011 UART
+            "/dev/ttyS0",     // miniUART or SoC UART
+            "/dev/ttyUSB0",   // USB-serial adapters
+            "/dev/ttyUSB1",
+            "/dev/ttyACM0",   // CDC ACM devices (e.g., some boards)
+            "/dev/ttyACM1"
+        };
+    }
+
+    bool fileExists(const std::string& path) {
+        return access(path.c_str(), F_OK) == 0;
+    }
+
+    // Also scan /dev for matching prefixes when fixed candidates fail
+    std::string scanDevByPrefixes(const std::vector<std::string>& prefixes) {
+        DIR* dir = opendir("/dev");
+        if (!dir) return "";
+        std::string found;
+        struct dirent* entry;
+        while ((entry = readdir(dir)) != nullptr) {
+            std::string name = entry->d_name;
+            for (const auto& prefix : prefixes) {
+                if (name.rfind(prefix.substr(5), 0) == 0) { // compare after "/dev/"
+                    found = std::string("/dev/") + name;
+                    closedir(dir);
+                    return found;
+                }
+            }
+        }
+        closedir(dir);
+        return "";
+    }
+
+    speed_t baudToSpeed(int baudRate) {
+        switch (baudRate) {
+            case 50: return B50;
+            case 75: return B75;
+            case 110: return B110;
+            case 134: return B134;
+            case 150: return B150;
+            case 200: return B200;
+            case 300: return B300;
+            case 600: return B600;
+            case 1200: return B1200;
+            case 1800: return B1800;
+            case 2400: return B2400;
+            case 4800: return B4800;
+            case 9600: return B9600;
+            case 19200: return B19200;
+            case 38400: return B38400;
+            case 57600: return B57600;
+            case 115200: return B115200;
+            case 230400: return B230400;
+            default: return B9600;
+        }
+    }
+
+    std::string autoDetectPort() {
+        // 1) Try prioritized list
+        for (const auto& candidate : getCandidatePorts()) {
+            if (fileExists(candidate)) return candidate;
+        }
+        // 2) Fallback scan of /dev for common serial device families
+        std::string fromScan = scanDevByPrefixes({
+            "/dev/ttyUSB", "/dev/ttyACM", "/dev/ttyAMA", "/dev/ttyS"
+        });
+        return fromScan;
+    }
+}
 
 SerialReader::SerialReader(const std::string& port, int baudRate) {
-    fd = open(port.c_str(), O_RDWR | O_NOCTTY);
+    std::string resolvedPort = port;
+    if (resolvedPort.empty() || resolvedPort == "auto") {
+        resolvedPort = autoDetectPort();
+        if (resolvedPort.empty()) {
+            std::cerr << "No serial device found. Specify a port explicitly." << std::endl;
+            exit(1);
+        }
+        std::cout << "Auto-detected serial port: " << resolvedPort << std::endl;
+    }
+
+    fd = open(resolvedPort.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
     if (fd < 0) {
         perror("Serial open failed");
         exit(1);
     }
 
     struct termios tty{};
-    tcgetattr(fd, &tty);
-    cfsetospeed(&tty, B9600);
-    cfsetispeed(&tty, B9600);
-    tty.c_cflag |= (CLOCAL | CREAD);
+    if (tcgetattr(fd, &tty) != 0) {
+        perror("tcgetattr failed");
+        exit(1);
+    }
+
+    // Set baud rate
+    speed_t speed = baudToSpeed(baudRate);
+    cfsetospeed(&tty, speed);
+    cfsetispeed(&tty, speed);
+
+    // 8N1, no flow control, local mode, enable receiver
+    tty.c_cflag &= ~PARENB;            // no parity
+    tty.c_cflag &= ~CSTOPB;            // 1 stop bit
     tty.c_cflag &= ~CSIZE;
-    tty.c_cflag |= CS8;
-    tcsetattr(fd, TCSANOW, &tty);
+    tty.c_cflag |= CS8;                // 8 bits
+    tty.c_cflag &= ~CRTSCTS;           // no HW flow control
+    tty.c_cflag |= (CLOCAL | CREAD);   // local connection, enable receiver
+
+    tty.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG); // raw input
+    tty.c_iflag &= ~(IXON | IXOFF | IXANY);         // no SW flow control
+    tty.c_oflag &= ~OPOST;                          // raw output
+
+    // Read returns as soon as at least 1 byte is available, with ~0.5s timeout
+    tty.c_cc[VMIN] = 0;
+    tty.c_cc[VTIME] = 5; // 0.5s (in deciseconds)
+
+    if (tcsetattr(fd, TCSANOW, &tty) != 0) {
+        perror("tcsetattr failed");
+        exit(1);
+    }
+
+    // Clear O_NONBLOCK after configuring timeouts to allow VTIME to work as expected
+    int flags = fcntl(fd, F_GETFL, 0);
+    fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
 }
 
 std::string SerialReader::readWeight() {
-    char buf[100];
-    int n = read(fd, buf, sizeof(buf));
-    if (n > 0) return std::string(buf, n);
+    // Read a line or current buffer
+    std::string data;
+    char buf[256];
+    ssize_t n = read(fd, buf, sizeof(buf));
+    if (n > 0) {
+        data.assign(buf, buf + n);
+        // If the device sends lines, return up to newline
+        std::size_t pos = data.find('\n');
+        if (pos != std::string::npos) {
+            return data.substr(0, pos);
+        }
+        return data;
+    }
     return "";
 }


### PR DESCRIPTION

### Serial Handler: Multi-Controller, Auto-Configuring

The `SerialReader` now supports Linux-based controllers such as Raspberry Pi and boards connected via USB (e.g., ESP32 over USB-serial). It can auto-detect the appropriate serial device and configure termios accordingly.

### Key Capabilities
- **Auto-detection**: Finds a usable serial device when `port` is `""` or `"auto"`.
- **Cross-controller support**: Works with Raspberry Pi onboard UARTs and generic USB/ACM serial adapters.
- **Robust termios setup**: 8N1, raw mode, no flow control, configurable baud rate, sensible read timeouts.

### Auto-Detection Logic
The constructor tries devices in this order:
1. `/dev/serial0` (Raspberry Pi alias)
2. `/dev/ttyAMA0` (RPi PL011)
3. `/dev/ttyS0` (miniUART/SoC UART)
4. `/dev/ttyUSB0`, `/dev/ttyUSB1` (USB-serial)
5. `/dev/ttyACM0`, `/dev/ttyACM1` (CDC ACM)
6. If none exist, scans `/dev` for names starting with `ttyUSB`, `ttyACM`, `ttyAMA`, or `ttyS`.

If no device is found, it prints an error and exits.

### Baud Rate Handling
- Accepts common baud rates and maps them to termios constants.
- Defaults to **9600** if an unsupported rate is provided.

### Serial Configuration
- **Mode**: 8 data bits, no parity, 1 stop bit (8N1)
- **Flow control**: Disabled (no HW/SW flow control)
- **I/O**: Raw input/output
- **Timeouts**: Non-blocking semantics replaced with `VMIN=0`, `VTIME=5` (≈0.5s read timeout)

### Usage
```cpp
// Auto-detect the serial port (recommended for Raspberry Pi and USB-serial)
SerialReader serial("auto", 9600);

// Or specify an explicit device path
SerialReader serial("/dev/ttyUSB0", 115200);

// Read weight data
std::string weight = serial.readWeight();
if (!weight.empty()) {
    std::cout << "Weight: " << weight << std::endl;
}
```

### Notes
- Designed for Linux environments (Raspberry Pi OS, typical Linux distros). Windows support would require a separate implementation path.
- If your system uses a non-standard device path, pass it explicitly to the constructor.